### PR TITLE
generate Gemfiles that bring in `rubysl` for :rbx by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+
+platform :rbx do
+  gem 'rubysl'
+end

--- a/lib/ggem/template_file/Gemfile.erb
+++ b/lib/ggem/template_file/Gemfile.erb
@@ -4,3 +4,7 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+
+platform :rbx do
+  gem 'rubysl'
+end


### PR DESCRIPTION
This is an intelligent default for writing gems targeting :rbx.  Bring
in the full standard library by default - back this down on specific
gems as needed.

@jcredding ready for review.
