### PR TITLE
lock into pry v0.9.x releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 platform :rbx do
   gem 'rubysl'

--- a/lib/ggem/template_file/Gemfile.erb
+++ b/lib/ggem/template_file/Gemfile.erb
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 platform :rbx do
   gem 'rubysl'


### PR DESCRIPTION
Pry v0.10.x has dropped support for 1.8.7.  This prevents bringing
in that dependency and breaking 1.8.7 compatible gems.

@jcredding ready for review.
