### PR TITLE
generate/require a test support factory

### DIFF
--- a/ggem.gemspec
+++ b/ggem.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.0"])
+  gem.add_development_dependency("assert", ["~> 2.10"])
 
 end

--- a/lib/ggem/template.rb
+++ b/lib/ggem/template.rb
@@ -27,7 +27,8 @@ module GGem
       save_file('lib.rb.erb',         "lib/#{@gem.ruby_name}.rb")
       save_file('lib_version.rb.erb', "lib/#{@gem.ruby_name}/version.rb")
 
-      save_file('test_helper.rb.erb', 'test/helper.rb')
+      save_file('test_helper.rb.erb',          'test/helper.rb')
+      save_file('test_support_factory.rb.erb', 'test/support/factory.rb')
 
       save_empty_file('log/.gitkeep')
       save_empty_file('tmp/.gitkeep')

--- a/lib/ggem/template_file/gemspec.erb
+++ b/lib/ggem/template_file/gemspec.erb
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert")
+  gem.add_development_dependency("assert", ["~> 2.10"])
   # TODO: gem.add_dependency("gem-name", ["~> 0.0"])
 
 end

--- a/lib/ggem/template_file/test_helper.rb.erb
+++ b/lib/ggem/template_file/test_helper.rb.erb
@@ -7,4 +7,6 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'test/suppport/factory'
+
 # TODO: put test helpers here...

--- a/lib/ggem/template_file/test_support_factory.rb.erb
+++ b/lib/ggem/template_file/test_support_factory.rb.erb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,8 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'test/support/factory'
+
 class Assert::Context
 
   TMP_PATH = File.expand_path "../../tmp", __FILE__

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/support/name_set.rb
+++ b/test/support/name_set.rb
@@ -29,6 +29,7 @@ module GGem
           "lib/#{@ruby_name}/version.rb",
 
           "test/helper.rb",
+          "test/support/factory.rb",
 
           "log/.gitkeep",
           "tmp/.gitkeep",


### PR DESCRIPTION
This switches to require a modern assert version that provides factory
logic.  This then auto-generates and requires in a top-level `Factory`
implementation that extends assert's factory.

This means all generated gems will have factory logic available by
default.

@jcredding ready for review.
