### PR TITLE
Fix `test/helper` requiring `test/suppport/factory` (with 3 p's)

### DIFF
--- a/lib/ggem/template_file/test_helper.rb.erb
+++ b/lib/ggem/template_file/test_helper.rb.erb
@@ -7,6 +7,6 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-require 'test/suppport/factory'
+require 'test/support/factory'
 
 # TODO: put test helpers here...


### PR DESCRIPTION
This fixes a type in the `test/helper` template where it requires
`test/support/factory`. It previously used `suppport` (3 p's)
instead of `support`. This fixes the typo so it won't fail when
requiring the `test/helper`.

@kellyredding - Ready for review.
