### PR TITLE
update generate gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rake'
+gem 'rake', "~> 10.4.0"
 gem 'pry', "~> 0.9.0"
-
-platform :rbx do
-  gem 'rubysl'
-end

--- a/lib/ggem/template_file/Gemfile.erb
+++ b/lib/ggem/template_file/Gemfile.erb
@@ -2,9 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rake'
+gem 'rake', "~> 10.4.0"
 gem 'pry', "~> 0.9.0"
-
-platform :rbx do
-  gem 'rubysl'
-end


### PR DESCRIPTION
This locks in rake to a 1.8.7 and up compatible version and stops
auto-generating rbx-specific settings.  This is just cleanup to
make sure generated gems are backwards compatible with 1.8.7 out of
the gate.

@jcredding ready for review.