### PR TITLE
rework to support multiple sub-commands

### DIFF
--- a/bin/ggem
+++ b/bin/ggem
@@ -4,4 +4,4 @@
 #
 
 require 'ggem/cli'
-GGem::CLI.run *ARGV
+GGem::CLI.run ARGV

--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -1,106 +1,91 @@
-require 'ggem'
 require 'ggem/version'
+require 'ggem/clirb'
+
+require 'ggem/gem'
 
 module GGem
 
   class CLI
 
-    def self.run(*args)
-      self.new.run(*args)
+    COMMANDS = Hash.new{ |h, k| NullCommand.new(k) }.tap do |h|
+      h['generate'] = GGem::Gem::CLI
+      h['g']        = GGem::Gem::CLI
     end
 
-    def initialize
-      @cli = CLIRB.new do
-        option 'debug', 'run in debug mode'
-      end
+    def self.run(args)
+      self.new.run(args)
     end
 
-    def run(*args)
+    def initialize(kernel = nil, stdout = nil, stderr = nil)
+      @kernel = kernel || Kernel
+      @stdout = stdout || $stdout
+      @stderr = stderr || $stderr
+    end
+
+    def run(args)
       begin
-        # parse manually in the case that parsing fails before the debug arg
-        debug_mode ||= args.include?('-d') || args.include?('--debug')
-        @cli.parse!(args)
-        raise CLIRB::Error, "please provide a gem name" if @cli.args.size < 1
-
-        path = GGem::Gem.new(Dir.pwd, *args).save!.path
-        puts "created gem and initialized git repo in #{path}"
+        command_name = args.shift
+        command = COMMANDS[command_name].new(args)
+        command.init
+        command.run
       rescue CLIRB::HelpExit
-        puts help
+        @stdout.puts command.help
       rescue CLIRB::VersionExit
-        puts GGem::VERSION
-      rescue CLIRB::Error => exception
-        puts "#{exception.message}\n\n"
-        puts  debug_mode ? exception.backtrace.join("\n") : help
-        exit(1)
-      rescue Exception => exception
-        puts "#{exception.class}: #{exception.message}"
-        puts exception.backtrace.join("\n") if debug_mode
-        exit(1)
+        @stdout.puts GGem::VERSION
+      rescue CLIRB::Error, ArgumentError, InvalidCommandError => exception
+        display_debug(exception)
+        @stderr.puts "#{exception.message}\n\n"
+        @stdout.puts command.help
+        @kernel.exit 1
+      rescue StandardError => exception
+        @stderr.puts "#{exception.class}: #{exception.message}"
+        @stderr.puts exception.backtrace.join("\n")
+        @kernel.exit 1
       end
-      exit(0)
+      @kernel.exit 0
+    end
+
+    private
+
+    def display_debug(exception)
+      if ENV['DEBUG']
+        @stderr.puts "#{exception.class}: #{exception.message}"
+        @stderr.puts exception.backtrace.join("\n")
+      end
+    end
+
+  end
+
+  class NullCommand
+    attr_reader :name, :argv, :clirb
+
+    def initialize(name)
+      @name = name
+      @argv = []
+      @clirb = GGem::CLIRB.new
+    end
+
+    def new(args)
+      @argv = [ @name, args ].flatten.compact
+      self
+    end
+
+    def init
+      @clirb.parse!(@argv)
+      raise CLIRB::HelpExit if @clirb.args.empty? || @name.to_s.empty?
+    end
+
+    def run
+      raise InvalidCommandError, "'#{self.name}' is not a command."
     end
 
     def help
-      "Usage: ggem GEM-NAME\n\n"\
-      "Options:"\
-      "#{@cli}"
-    end
-
-  end
-
-  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
-    Error    = Class.new(RuntimeError);
-    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
-    attr_reader :argv, :args, :opts, :data
-
-    def initialize(&block)
-      @options = []; instance_eval(&block) if block
-      require 'optparse'
-      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
-        p.banner = ''; @options.each do |o|
-          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
-        end
-        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
-        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
-      end
-    end
-
-    def option(*args); @options << Option.new(*args); end
-    def parse!(argv)
-      @args = (argv || []).dup.tap do |args_list|
-        begin; @parser.parse!(args_list)
-        rescue OptionParser::ParseError => err; raise Error, err.message; end
-      end; @data = @args + [@opts]
-    end
-    def to_s; @parser.to_s; end
-    def inspect
-      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
-    end
-
-    class Option
-      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
-
-      def initialize(name, *args)
-        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
-        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
-        @value, @klass = gvalinfo(settings[:value])
-        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
-          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
-        else
-          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
-        end
-      end
-
-      private
-
-      def parse_name_values(name, custom_abbrev)
-        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
-          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
-        ]
-      end
-      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
-      def gklass(k); k == Fixnum ? Integer : k; end
+      "Usage: ggem [COMMAND] [options]\n\n" \
+      "Commands: #{GGem::CLI::COMMANDS.keys.sort.join(', ')}\n" \
+      "Options: #{@clirb}"
     end
   end
+
+  InvalidCommandError = Class.new(ArgumentError)
 
 end

--- a/lib/ggem/clirb.rb
+++ b/lib/ggem/clirb.rb
@@ -1,0 +1,58 @@
+module GGem
+
+  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
+    Error    = Class.new(RuntimeError);
+    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
+    attr_reader :argv, :args, :opts, :data
+
+    def initialize(&block)
+      @options = []; instance_eval(&block) if block
+      require 'optparse'
+      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
+        p.banner = ''; @options.each do |o|
+          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+        end
+        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
+        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      end
+    end
+
+    def option(*args); @options << Option.new(*args); end
+    def parse!(argv)
+      @args = (argv || []).dup.tap do |args_list|
+        begin; @parser.parse!(args_list)
+        rescue OptionParser::ParseError => err; raise Error, err.message; end
+      end; @data = @args + [@opts]
+    end
+    def to_s; @parser.to_s; end
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    end
+
+    class Option
+      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
+
+      def initialize(name, *args)
+        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+        @value, @klass = gvalinfo(settings[:value])
+        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
+          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+        else
+          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
+        end
+      end
+
+      private
+
+      def parse_name_values(name, custom_abbrev)
+        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+        ]
+      end
+      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
+      def gklass(k); k == Fixnum ? Integer : k; end
+    end
+  end
+
+end

--- a/lib/ggem/gem.rb
+++ b/lib/ggem/gem.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'ggem/clirb'
 require 'ggem/template'
 
 module GGem
@@ -8,6 +9,7 @@ module GGem
     attr_reader :root_path, :name
 
     def initialize(path, name)
+      raise NoNameError if name.to_s.empty?
       @root_path, self.name = path, name
     end
 
@@ -20,7 +22,10 @@ module GGem
     def name=(name); @name = normalize_name(name); end
 
     def module_name
-      transforms = {'_' => '', '-' => ''}
+      transforms = {
+        '_' => '',
+        '-' => ''
+      }
       @module_name ||= transform_name(transforms){ |part| part.capitalize }
     end
 
@@ -45,6 +50,40 @@ module GGem
         end
       end
       n
+    end
+
+    NoNameError = Class.new(ArgumentError)
+
+    class CLI
+
+      attr_reader :clirb
+
+      def initialize(argv, stdout = nil)
+        @argv = argv
+        @stdout = stdout || $stdout
+
+        @clirb = GGem::CLIRB.new
+      end
+
+      def init
+        @clirb.parse!(@argv)
+      end
+
+      def run
+        gem_name = @clirb.args.first
+        path = GGem::Gem.new(Dir.pwd, gem_name).save!.path
+        @stdout.puts "created gem and initialized git repo in #{path}"
+      rescue NoNameError => exception
+        error = ArgumentError.new("GEM-NAME must be provided")
+        error.set_backtrace(exception.backtrace)
+        raise error
+      end
+
+      def help
+        "Usage: ggem generate [options] GEM-NAME\n\n" \
+        "Options: #{@clirb}"
+      end
+
     end
 
   end

--- a/lib/ggem/template.rb
+++ b/lib/ggem/template.rb
@@ -2,6 +2,7 @@ require 'erb'
 require 'fileutils'
 
 module GGem
+
   class Template
 
     def initialize(ggem)
@@ -67,4 +68,5 @@ module GGem
     end
 
   end
+
 end

--- a/test/system/ggem_tests.rb
+++ b/test/system/ggem_tests.rb
@@ -5,7 +5,7 @@ require 'test/support/name_set'
 
 module GGem
 
-  class BaseTests < Assert::Context
+  class SystemTests < Assert::Context
     desc "GGem"
 
     NS_SIMPLE = GGem::NameSet::Simple
@@ -18,8 +18,8 @@ module GGem
 
   end
 
-  class SaveTests < BaseTests
-    desc "when saving gems"
+  class SaveTests < SystemTests
+    desc "when saving new gems"
     setup_once do
       FileUtils.rm_rf(TMP_PATH)
       FileUtils.mkdir_p(TMP_PATH)

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,0 +1,291 @@
+require 'assert'
+require 'ggem/cli'
+
+require 'ggem/gem'
+
+class GGem::CLI
+
+  class UnitTests < Assert::Context
+    desc "GGem::CLI"
+    setup do
+      @cli_class = GGem::CLI
+    end
+    subject{ @cli_class }
+
+    should have_imeths :run
+
+    should "build and run an instance of itself using `run`" do
+      cli_spy = CLISpy.new
+      Assert.stub(subject, :new).with{ cli_spy }
+
+      args = [Factory.string]
+      subject.run(args)
+      assert_equal args, cli_spy.run_called_with
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @kernel_spy = KernelSpy.new
+      @stdout = IOSpy.new
+      @stderr = IOSpy.new
+
+      @cli = @cli_class.new(@kernel_spy, @stdout, @stderr)
+    end
+    subject{ @cli }
+
+    should have_imeths :run
+
+    should "know its commands" do
+      assert_equal 2, COMMANDS.size
+
+      assert_equal GGem::Gem::CLI, COMMANDS['generate']
+      assert_equal GGem::Gem::CLI, COMMANDS['g']
+    end
+
+  end
+
+  class RunSetupTests < InitTests
+    setup do
+      @command_name = Factory.string
+      @argv = [ @command_name, Factory.string ]
+
+      @command_class = Class.new
+      COMMANDS[@command_name] = @command_class
+
+      @command_spy = CommandSpy.new
+      Assert.stub(@command_class, :new).with(@argv){ @command_spy }
+
+      @null_command = GGem::NullCommand.new(@command_name)
+    end
+    teardown do
+      COMMANDS.delete(@command_name)
+    end
+
+  end
+
+  class RunTests < RunSetupTests
+    desc "and run"
+    setup do
+      @cli.run(@argv)
+    end
+
+    should "have init and run the command" do
+      assert_true @command_spy.init_called
+      assert_true @command_spy.run_called
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithNoArgsTests < RunSetupTests
+    desc "and run with no args"
+    setup do
+      @cli.run([])
+    end
+
+    should "have output its null commands help" do
+      assert_equal @null_command.help, @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithInvalidCommandTests < RunSetupTests
+    desc "and run with an invalid command"
+    setup do
+      @name = Factory.string
+      @argv.unshift(@name)
+      @cli.run(@argv)
+    end
+
+    should "have output that its invalid and its null commands help" do
+      exp = "'#{@name}' is not a command.\n\n"
+      assert_equal exp, @stderr.read
+      assert_equal @null_command.help, @stdout.read
+    end
+
+    should "have unsuccessfully exited" do
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithHelpTests < RunSetupTests
+    desc "and run with the help switch"
+    setup do
+      @cli.run([ '--help' ])
+    end
+
+    should "have output its null commands help" do
+      assert_equal @null_command.help, @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithVersionTests < RunSetupTests
+    desc "and run with the version switch"
+    setup do
+      @cli.run([ '--version' ])
+    end
+
+    should "have output its version" do
+      assert_equal "#{GGem::VERSION}\n", @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithErrorTests < RunSetupTests
+    setup do
+      @exception = RuntimeError.new(Factory.string)
+      Assert.stub(@command_class, :new).with(@argv){ raise @exception }
+      @cli.run(@argv)
+    end
+
+    should "have output an error message" do
+      exp = "#{@exception.class}: #{@exception.message}\n" \
+            "#{@exception.backtrace.join("\n")}\n"
+      assert_equal exp, @stderr.read
+      assert_empty @stdout.read
+    end
+
+    should "have unsuccessfully exited" do
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class NullCommandTests < UnitTests
+    desc "NullCommand"
+    setup do
+      @name = Factory.string
+      @null_command = GGem::NullCommand.new(@name)
+    end
+    subject{ @null_command }
+
+    should have_readers :name, :argv, :clirb
+    should have_imeths :new, :init, :run, :help
+
+    should "know its name, argv and clirb" do
+      assert_equal @name, subject.name
+      assert_equal [], subject.argv
+      assert_instance_of GGem::CLIRB, subject.clirb
+    end
+
+    should "set its argv and return itself using `new`" do
+      args = [ Factory.string, Factory.string ]
+      result = subject.new(args)
+      assert_same subject, result
+      assert_equal [ @name, args ].flatten, subject.argv
+    end
+
+    should "parse its argv when `init`" do
+      subject.new([ '--help' ])
+      assert_raises(GGem::CLIRB::HelpExit){ subject.init }
+      subject.new([ '--version' ])
+      assert_raises(GGem::CLIRB::VersionExit){ subject.init }
+    end
+
+    should "raise a help exit if its argv is empty when `init`" do
+      null_command = GGem::NullCommand.new(nil)
+      null_command.new([])
+      assert_raises(GGem::CLIRB::HelpExit){ null_command.init }
+
+      null_command = GGem::NullCommand.new("")
+      null_command.new([])
+      assert_raises(GGem::CLIRB::HelpExit){ null_command.init }
+    end
+
+    should "raise an invalid command error when run" do
+      assert_raises(GGem::InvalidCommandError){ subject.run }
+    end
+
+    should "know its help" do
+      exp = "Usage: ggem [COMMAND] [options]\n\n" \
+            "Commands: #{COMMANDS.keys.sort.join(', ')}\n" \
+            "Options: #{subject.clirb}"
+      assert_equal exp, subject.help
+    end
+
+  end
+
+  class CLISpy
+    attr_reader :run_called_with
+
+    def initialize
+      @run_called_with = nil
+    end
+
+    def run(args)
+      @run_called_with = args
+    end
+  end
+
+  class CommandSpy
+    attr_reader :init_called, :run_called
+
+    def initialize
+      @init_called = false
+      @run_called = false
+    end
+
+    def init
+      @init_called = true
+    end
+
+    def run
+      @run_called = true
+    end
+
+    def help
+      Factory.text
+    end
+  end
+
+  class KernelSpy
+    attr_reader :exit_status
+
+    def initialize
+      @exit_status = nil
+    end
+
+    def exit(code)
+      @exit_status ||= code
+    end
+  end
+
+  class IOSpy
+    def initialize
+      @io = StringIO.new
+    end
+
+    def puts(message)
+      @io.puts message
+    end
+
+    def read
+      @io.rewind
+      @io.read
+    end
+  end
+
+end

--- a/test/unit/gem_tests.rb
+++ b/test/unit/gem_tests.rb
@@ -1,23 +1,140 @@
 require "assert"
 require "ggem/gem"
 
+require 'ggem/clirb'
+
 class GGem::Gem
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "GGem::Gem"
     setup do
-      @gem = GGem::Gem.new(TMP_PATH, 'a-gem')
+      @gem_class = GGem::Gem
     end
-    subject { @gem }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @gem_name = Factory.string
+      @gem = @gem_class.new(TMP_PATH, @gem_name)
+    end
+    subject{ @gem }
 
     should have_readers :root_path, :name
     should have_imeths  :save!, :path, :name=, :module_name, :ruby_name
 
     should "know its root path and path" do
       assert_equal TMP_PATH, subject.root_path
-      assert_equal File.join(TMP_PATH, 'a-gem'), subject.path
+      assert_equal File.join(TMP_PATH, @gem_name), subject.path
     end
 
+    should "complain if no name is provided" do
+      assert_raises(NoNameError) do
+        @gem_class.new(TMP_PATH, [nil, ''].choice)
+      end
+    end
+
+    # most of the gem's behavior is covered in the system tests
+
+  end
+
+  class CLITests < UnitTests
+    desc "CLI"
+    setup do
+      @name = Factory.string
+
+      @path = Factory.dir_path
+      Assert.stub(Dir, :pwd){ @path }
+
+      @new_called_with = []
+      @gem_spy         = GemSpy.new
+      Assert.stub(@gem_class, :new) do |*args|
+        @new_called_with = args
+        @gem_spy
+      end
+
+      @stdout = IOSpy.new
+      @cli = CLI.new([@name], @stdout)
+    end
+    subject{ @cli }
+
+    should have_readers :clirb
+
+    should "know its CLI.RB" do
+      assert_instance_of GGem::CLIRB, subject.clirb
+    end
+
+    should "know its help" do
+      exp = "Usage: ggem generate [options] GEM-NAME\n\n" \
+            "Options: #{subject.clirb}"
+      assert_equal exp, subject.help
+    end
+
+    should "parse its args when `init`" do
+      subject.init
+      assert_equal [@name], subject.clirb.args
+    end
+
+    should "init and save a gem when run" do
+      subject.init
+      subject.run
+
+      assert_equal [@path, @name], @new_called_with
+      assert_true @gem_spy.save_called
+
+      exp = "created gem and initialized git repo in #{@gem_spy.path}\n"
+      assert_equal exp, @stdout.read
+    end
+
+    should "re-raise a specific argument error on gem 'no name' errors" do
+      Assert.stub(@gem_class, :new) { raise NoNameError }
+      err = nil
+      begin
+        cli = CLI.new([])
+        cli.init
+        cli.run
+      rescue ArgumentError => err
+      end
+
+      assert_not_nil err
+      exp = "GEM-NAME must be provided"
+      assert_equal exp, err.message
+      assert_not_empty err.backtrace
+    end
+
+  end
+
+  class GemSpy
+    attr_reader :save_called
+
+    def initialize
+      @save_called = false
+    end
+
+    def save!
+      @save_called = true
+      self
+    end
+
+    def path
+      @path ||= Factory.path
+    end
+  end
+
+  class IOSpy
+    def initialize
+      @io = StringIO.new
+    end
+
+    def puts(message)
+      @io.puts message
+    end
+
+    def read
+      @io.rewind
+      @io.read
+    end
   end
 
 end


### PR DESCRIPTION
This reworks the CLI to take many sub-commands where the command is
specified as the first arg to the main `ggem` cli.  This also ports
the existing behavior as the first sub-command: `generate` (aliased
as `g`.

Note: this also updates some style things to get the code and tests
up to our modern conventions.

@jcredding ready for review.  Most of the implementation and tests were ripped off from our internal sub-command CLI, btw.