### PR TITLE
cli: add support for command exit errors

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -38,6 +38,8 @@ module GGem
         @stderr.puts "#{exception.message}\n\n"
         @stdout.puts cmd.help
         @kernel.exit 1
+      rescue CommandExitError
+        @kernel.exit 1
       rescue StandardError => exception
         @stderr.puts "#{exception.class}: #{exception.message}"
         @stderr.puts exception.backtrace.join("\n")
@@ -54,6 +56,9 @@ module GGem
         @stderr.puts exception.backtrace.join("\n")
       end
     end
+
+    InvalidCommandError = Class.new(ArgumentError)
+    CommandExitError    = Class.new(RuntimeError)
 
     class InvalidCommand
 
@@ -86,8 +91,6 @@ module GGem
       end
 
     end
-
-    InvalidCommandError = Class.new(ArgumentError)
 
     class GenerateCommand
 

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -8,6 +8,10 @@ class GGem::CLI
   class UnitTests < Assert::Context
     desc "GGem::CLI"
     setup do
+      @kernel_spy = KernelSpy.new
+      @stdout     = IOSpy.new
+      @stderr     = IOSpy.new
+
       @cli_class = GGem::CLI
     end
     subject{ @cli_class }
@@ -37,10 +41,6 @@ class GGem::CLI
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @kernel_spy = KernelSpy.new
-      @stdout     = IOSpy.new
-      @stderr     = IOSpy.new
-
       @cli = @cli_class.new(@kernel_spy, @stdout, @stderr)
     end
     subject{ @cli }
@@ -118,6 +118,20 @@ class GGem::CLI
 
     should "have unsuccessfully exited" do
       assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithCommandExitErrorTests < RunSetupTests
+    desc "and run with a command that error exits"
+    setup do
+      Assert.stub(@command_spy, :init){ raise CommandExitError }
+      @cli.run(@argv)
+    end
+
+    should "have unsuccessfully exited with no stderr output" do
+      assert_equal 1, @kernel_spy.exit_status
+      assert_empty @stderr.read
     end
 
   end


### PR DESCRIPTION
This is a custom exception that tells the CLI to just exit with
a non-zero status but don't output any error or help info.  This
isn't needed by any specific sub-commands but should be something
available to all sub commands.

This was needed by an Ardb sub command so we are making it a standard
for our sub command pattern/framework.

@jcredding ready for review.