### PR TITLE
some cleanups to the test helpers and system tests

### DIFF
--- a/lib/ggem/gem.rb
+++ b/lib/ggem/gem.rb
@@ -1,5 +1,4 @@
 require 'fileutils'
-require 'ggem/clirb'
 require 'ggem/template'
 
 module GGem

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,52 +2,12 @@
 # put any test helpers here
 
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+require 'pathname'
+ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
+$LOAD_PATH.unshift(ROOT_PATH.to_s)
+TMP_PATH = ROOT_PATH.join('tmp')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
 require 'test/support/factory'
-
-class Assert::Context
-
-  TMP_PATH = File.expand_path "../../tmp", __FILE__
-
-  def self.create_paths(name_set)
-    called_from = caller.first
-    folders = name_set.expected_folders
-    files = name_set.expected_files
-
-    paths = (folders + files).collect{|p| File.join(TMP_PATH, name_set.name, p)}
-    macro_name =  "create the paths: #{paths.join(', ')}"
-
-    Assert::Macro.new(macro_name) do
-      paths.flatten.each do |path|
-        should "create the path '#{path}'", called_from do
-          assert File.exists?(path), "'#{path}' does not exist"
-        end
-      end
-    end
-
-  end
-
-  def self.generate_name_set(name_set)
-    called_from = caller.first
-    macro_name =  "generate the name_set: #{name_set.inspect}"
-
-    Assert::Macro.new(macro_name) do
-      name_set.variations.each do |variation|
-        [:name, :module_name, :ruby_name].each do |name_type|
-          should "know its :#{name_type} given '#{variation}'", called_from do
-            the_gem = GGem::Gem.new(TMP_PATH, variation)
-            assert_equal name_set.send(name_type), the_gem.send(name_type)
-          end
-        end
-      end
-    end
-
-  end
-
-end
-
-

--- a/test/support/system_tests_helpers.rb
+++ b/test/support/system_tests_helpers.rb
@@ -1,0 +1,41 @@
+module GGem
+
+  module SystemTestsHelpers
+
+    def create_paths(name_set)
+      called_from = caller.first
+      folders = name_set.expected_folders
+      files = name_set.expected_files
+
+      paths = (folders + files).collect{|p| File.join(TMP_PATH, name_set.name, p)}
+      macro_name =  "create the paths: #{paths.join(', ')}"
+
+      Assert::Macro.new(macro_name) do
+        paths.flatten.each do |path|
+          should "create the path '#{path}'", called_from do
+            assert File.exists?(path), "'#{path}' does not exist"
+          end
+        end
+      end
+
+    end
+
+    def generate_name_set(name_set)
+      called_from = caller.first
+      macro_name =  "generate the name_set: #{name_set.inspect}"
+
+      Assert::Macro.new(macro_name) do
+        name_set.variations.each do |variation|
+          [:name, :module_name, :ruby_name].each do |name_type|
+            should "know its :#{name_type} given '#{variation}'", called_from do
+              the_gem = GGem::Gem.new(TMP_PATH, variation)
+              assert_equal name_set.send(name_type), the_gem.send(name_type)
+            end
+          end
+        end
+      end
+    end
+
+  end
+
+end

--- a/test/system/ggem_tests.rb
+++ b/test/system/ggem_tests.rb
@@ -2,17 +2,20 @@ require 'assert'
 require 'ggem'
 
 require 'test/support/name_set'
+require 'test/support/system_tests_helpers'
 
 module GGem
 
   class SystemTests < Assert::Context
+    extend SystemTestsHelpers
+
     desc "GGem"
 
     NS_SIMPLE = GGem::NameSet::Simple
     NS_UNDER  = GGem::NameSet::Underscored
     NS_HYPHEN = GGem::NameSet::HyphenatedOther
 
-    [ NS_SIMPLE, NS_UNDER, NS_HYPHEN ].each do |ns|
+    [NS_SIMPLE, NS_UNDER, NS_HYPHEN].each do |ns|
       should generate_name_set(ns.new)
     end
 


### PR DESCRIPTION
The goal here is to prep for adding additional sub commands and
testing them.  Previously, GGem only did one thing: generate gems.
Soon it will do many different gem related functions so the tests
need to support this.  This effort does a few cleanups:

* introduce a formal `ROOT_PATH` constant which will be used in
  coming tests that expect files in the root
* move the `TMP_PATH` constant out of assert's context namespace
  and build relative to the new root path constant
* remove some assert context singleton helper methods from the
  global context and only extend them on the system tests context
  as they are only needed there - no need to pollute all test
  contexts with these
* do some various style cleanups that were missed in previous efforts

Overall, these changes make the tests less "hard coded" for testing
gem generation and will make it easier to test the new functions
that are coming.

@jcredding ready for review.  Are you cool with me shoving those singleton helper methods used in the system tests into that `SystemTestsHelpers` module?  I couldn't think of a better name right now.  I'm open to any clever suggestions!