### PR TITLE
model a gemspec object

### DIFF
--- a/ggem.gemspec
+++ b/ggem.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15"])
+  gem.add_development_dependency("assert", ["~> 2.15.0"])
+
+  gem.add_dependency("scmd", ["~> 3.0.1"])
 
 end

--- a/lib/ggem/gemspec.rb
+++ b/lib/ggem/gemspec.rb
@@ -1,0 +1,87 @@
+require 'pathname'
+require 'scmd'
+
+module GGem
+
+  class Gemspec
+
+    PUSH_HOST_META_KEY = 'allowed_push_host'
+    DEFAULT_PUSH_HOST  = 'https://rubygems.org'.freeze
+    BUILD_TO_DIRNAME   = 'pkg'.freeze
+
+    attr_reader :path, :name, :version
+    attr_reader :gem_file_name, :gem_file, :push_host
+
+    def initialize(root_path)
+      @root = Pathname.new(File.expand_path(root_path))
+      raise NotFoundError unless @root.exist?
+      @path = Pathname.new(Dir[File.join(@root, "{,*}.gemspec")].first.to_s)
+      raise NotFoundError unless @path.exist?
+
+      @spec    = load_gemspec(@path)
+      @name    = @spec.name
+      @version = @spec.version
+
+      @gem_file_name  = "#{@name}-#{@version}.gem"
+      @gem_file       = File.join(BUILD_TO_DIRNAME, @gem_file_name)
+      @built_gem_path = @root.join(@gem_file)
+
+      @push_host = get_push_host(@spec)
+    end
+
+    def run_build_cmd
+      run_cmd("gem build --verbose #{@path}", BuildError).tap do |c|
+        gem_path = @root.join(@gem_file_name)
+        run_cmd("mkdir -p #{@built_gem_path.dirname}", BuildError)
+        run_cmd("mv #{gem_path} #{@built_gem_path}",   BuildError)
+      end
+    end
+
+    def run_install_cmd
+      run_cmd("gem install #{@built_gem_path}", InstallError)
+    end
+
+    def run_push_cmd
+      run_cmd("gem push #{@built_gem_path} --host #{@push_host}", PushError)
+    end
+
+    private
+
+    def run_cmd(cmd_string, exception_class)
+      cmd = Scmd.new(cmd_string)
+      cmd.run
+      if !cmd.success?
+        raise exception_class, "#{cmd_string}\n" \
+                               "#{cmd.stderr.empty? ? cmd.stdout : cmd.stderr}"
+      end
+      [cmd_string, cmd.exitstatus, cmd.stdout]
+    end
+
+    def load_gemspec(path)
+      eval(path.read, TOPLEVEL_BINDING, path.expand_path.to_s)
+    rescue ScriptError, StandardError => e
+      original_line = e.backtrace.find{ |line| line.include?(path.to_s) }
+      msg = "There was a #{e.class} while loading #{path.basename}: \n#{e.message}"
+      msg << " from\n  #{original_line}" if original_line
+      msg << "\n"
+      raise LoadError, msg
+    end
+
+    def get_push_host(spec)
+      ENV['GGEM_PUSH_HOST'] || get_meta(spec)[PUSH_HOST_META_KEY] || DEFAULT_PUSH_HOST
+    end
+
+    def get_meta(spec)
+      (spec.respond_to?(:metadata) ? spec.metadata : {}) || {}
+    end
+
+    NotFoundError = Class.new(ArgumentError)
+    LoadError     = Class.new(ArgumentError)
+    CmdError      = Class.new(RuntimeError)
+    BuildError    = Class.new(CmdError)
+    InstallError  = Class.new(CmdError)
+    PushError     = Class.new(CmdError)
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,8 +6,11 @@ require 'pathname'
 ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 $LOAD_PATH.unshift(ROOT_PATH.to_s)
 TMP_PATH = ROOT_PATH.join('tmp')
+TEST_SUPPORT_PATH = ROOT_PATH.join('test/support')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
 require 'test/support/factory'
+
+ENV['SCMD_TEST_MODE'] = '1'

--- a/test/support/gem1/gem1.gemspec
+++ b/test/support/gem1/gem1.gemspec
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+Gem::Specification.new do |gem|
+  gem.name        = "gem1"
+  gem.version     = "0.1.0"
+  gem.authors     = []
+  gem.email       = []
+  gem.summary     = %q{Gem 1 summary}
+  gem.description = %q{Gem 1 description}
+  gem.license     = 'MIT'
+
+  gem.files         = []
+  gem.executables   = []
+  gem.test_files    = []
+  gem.require_paths = []
+
+end

--- a/test/support/gem2/gem2.gemspec
+++ b/test/support/gem2/gem2.gemspec
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+Gem::Specification.new do |gem|
+  gem.name        = "gem2"
+  gem.version     = "0.2.0"
+  gem.authors     = []
+  gem.email       = []
+  gem.summary     = %q{Gem 2 summary}
+  gem.description = %q{Gem 2 description}
+  gem.license     = 'MIT'
+
+  gem.metadata['allowed_push_host'] = 'http://gems.example.com'
+
+  gem.files         = []
+  gem.executables   = []
+  gem.test_files    = []
+  gem.require_paths = []
+
+end

--- a/test/unit/gemspec_tests.rb
+++ b/test/unit/gemspec_tests.rb
@@ -1,0 +1,217 @@
+require "assert"
+require "ggem/gemspec"
+
+require 'ggem/version'
+
+class GGem::Gemspec
+
+  class UnitTests < Assert::Context
+    desc "GGem::Gemspec"
+    setup do
+      @gemspec_class = GGem::Gemspec
+    end
+    subject{ @gemspec_class }
+
+    should "know the push host meta key" do
+      assert_equal 'allowed_push_host', subject::PUSH_HOST_META_KEY
+    end
+
+    should "use Rubygems as its default push host" do
+      assert_equal 'https://rubygems.org', subject::DEFAULT_PUSH_HOST
+    end
+
+    should "know which dir to build gems to" do
+      assert_equal 'pkg', subject::BUILD_TO_DIRNAME
+    end
+
+    should "know its exceptions" do
+      assert subject::NotFoundError < ArgumentError
+      assert subject::LoadError < ArgumentError
+      assert subject::CmdError < RuntimeError
+      assert subject::BuildError < CmdError
+      assert subject::InstallError < CmdError
+      assert subject::PushError < CmdError
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @gem1_root_path = TEST_SUPPORT_PATH.join('gem1')
+      @spec = @gemspec_class.new(@gem1_root_path)
+    end
+    subject{ @spec }
+
+    should have_readers :path, :name, :version
+    should have_readers :gem_file_name, :gem_file, :push_host
+    should have_imeths :run_build_cmd, :run_install_cmd, :run_push_cmd
+
+    should "know its attrs" do
+      exp = @gem1_root_path.join('gem1.gemspec')
+      assert_equal exp, subject.path
+
+      assert_equal 'gem1',  subject.name
+      assert_equal '0.1.0', subject.version.to_s
+
+      exp = "#{subject.name}-#{subject.version}.gem"
+      assert_equal exp, subject.gem_file_name
+
+      exp = File.join(@gemspec_class::BUILD_TO_DIRNAME, subject.gem_file_name)
+      assert_equal exp, subject.gem_file
+    end
+
+    should "know its push host" do
+      # gem1 has no meta host specified, so the default push host is used
+      assert_equal @gemspec_class::DEFAULT_PUSH_HOST, subject.push_host
+
+      # gem2 has a meta host specified, so that is used over the default
+      gem2_spec = @gemspec_class.new(TEST_SUPPORT_PATH.join('gem2'))
+      assert_equal 'http://gems.example.com', gem2_spec.push_host
+
+      # prefer the env push hosts over configured and default hosts
+      prev_env_push_host = ENV['GGEM_PUSH_HOST']
+      ENV['GGEM_PUSH_HOST'] = Factory.string
+      spec = @gemspec_class.new(TEST_SUPPORT_PATH.join(['gem1', 'gem2'].choice))
+      assert_equal ENV['GGEM_PUSH_HOST'], spec.push_host
+      ENV['GGEM_PUSH_HOST'] = prev_env_push_host
+    end
+
+    should "complain if the given gemspec root doesn't exist" do
+      assert_raises(NotFoundError) do
+        @gemspec_class.new('path/that-is/not-found')
+      end
+    end
+
+    should "complain if the given gemspec root contains no gemspec file" do
+      assert_raises(NotFoundError) do
+        @gemspec_class.new(TEST_SUPPORT_PATH)
+      end
+    end
+
+  end
+
+  class CmdTests < InitTests
+    setup do
+      @exp_build_path = @gem1_root_path.join(subject.gem_file_name)
+      @exp_pkg_path   = @gem1_root_path.join(@gemspec_class::BUILD_TO_DIRNAME, subject.gem_file_name)
+
+      @cmd_spy = nil
+      Scmd.reset
+    end
+    teardown do
+      Scmd.reset
+    end
+
+  end
+
+  class RunBuildCmdTests < CmdTests
+    desc "`run_build_cmd`"
+    setup do
+      @exp_cmds_run = [
+        "gem build --verbose #{subject.path}",
+        "mkdir -p #{@exp_pkg_path.dirname}",
+        "mv #{@exp_build_path} #{@exp_pkg_path}"
+      ]
+    end
+
+    should "run system cmds to build the gem" do
+      cmd_str, exitstatus, stdout = subject.run_build_cmd
+      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
+
+      assert_equal Scmd.calls.first.cmd_str,        cmd_str
+      assert_equal Scmd.calls.first.cmd.exitstatus, exitstatus
+      assert_equal Scmd.calls.first.cmd.stdout,     stdout
+    end
+
+    should "complain if any system cmds are not successful" do
+      err_cmd_str = @exp_cmds_run.choice
+      Scmd.add_command(err_cmd_str) do |cmd|
+        cmd.exitstatus = 1
+        cmd.stderr     = Factory.string
+        @cmd_spy       = cmd
+      end
+      err = nil
+      begin
+        subject.run_build_cmd
+      rescue StandardError => err
+      end
+
+      assert_kind_of BuildError, err
+      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
+      assert_equal exp, err.message
+    end
+
+  end
+
+  class RunInstallCmdTests < CmdTests
+    desc "`run_install_cmd`"
+    setup do
+      @exp_cmds_run = ["gem install #{@exp_pkg_path}"]
+    end
+
+    should "run a system cmd to install the gem" do
+      cmd_str, exitstatus, stdout = subject.run_install_cmd
+      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
+
+      assert_equal Scmd.calls.last.cmd_str,        cmd_str
+      assert_equal Scmd.calls.last.cmd.exitstatus, exitstatus
+      assert_equal Scmd.calls.last.cmd.stdout,     stdout
+    end
+
+    should "complain if the system cmd is not successful" do
+      err_cmd_str = @exp_cmds_run.choice
+      Scmd.add_command(err_cmd_str) do |cmd|
+        cmd.exitstatus = 1
+        cmd.stderr     = Factory.string
+        @cmd_spy       = cmd
+      end
+      err = nil
+      begin
+        subject.run_install_cmd
+      rescue StandardError => err
+      end
+
+      assert_kind_of InstallError, err
+      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
+      assert_equal exp, err.message
+    end
+
+  end
+
+  class RunPushCmdTests < CmdTests
+    desc "`run_push_cmd`"
+    setup do
+      @exp_cmds_run = ["gem push #{@exp_pkg_path} --host #{subject.push_host}"]
+    end
+
+    should "run a system cmd to push the gem to the push host" do
+      cmd_str, exitstatus, stdout = subject.run_push_cmd
+      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
+
+      assert_equal Scmd.calls.last.cmd_str,        cmd_str
+      assert_equal Scmd.calls.last.cmd.exitstatus, exitstatus
+      assert_equal Scmd.calls.last.cmd.stdout,     stdout
+    end
+
+    should "complain if the system cmd is not successful" do
+      err_cmd_str = @exp_cmds_run.choice
+      Scmd.add_command(err_cmd_str) do |cmd|
+        cmd.exitstatus = 1
+        cmd.stderr     = Factory.string
+        @cmd_spy       = cmd
+      end
+      err = nil
+      begin
+        subject.run_push_cmd
+      rescue StandardError => err
+      end
+
+      assert_kind_of PushError, err
+      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
+      assert_equal exp, err.message
+    end
+
+  end
+
+end


### PR DESCRIPTION
This models a gemspec.  It looks for a gemspec in a given root dir,
loads it and then can perform system commands on it.  This will be
used by the CLI to implement build, install and push sub-commands.

The `run_{build|install|push}_cmd` methods were all inspired by
Bundler's gem tasks.  However, instead of ripping off bundler's
implementation, I chose to have the commands just run the raw
system commands you could run manually.  This essentially means that
ggem's CLI commands will just be macros/aliases for the raw system
commands.  The end result, however, is the same as if you ran
bundler's corresponding rake tasks.

The goal with all of this is to provide an alternative to bundler's
rake tasks that doesn't rely on crappy Rake.  We are trying to
rid ourselves of all Rake dependency and this is part of that effort.

Note: this brings in the latest Scmd which has utils for spying and
testing Scmd calls.  

@jcredding ready for review.