### PR TITLE
add gemspec build, install and push sub commands to the CLI

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -7,9 +7,15 @@ module GGem
 
     class InvalidCommand;  end
     class GenerateCommand; end
+    class BuildCommand;    end
+    class InstallCommand;  end
+    class PushCommand;     end
     COMMANDS = Hash.new{ |h, k| InvalidCommand.new(k) }.tap do |h|
       h['generate'] = GenerateCommand
       h['g']        = GenerateCommand
+      h['build']    = BuildCommand
+      h['install']  = InstallCommand
+      h['push']     = PushCommand
     end
 
     def self.run(args)
@@ -87,18 +93,29 @@ module GGem
 
     end
 
-    class GenerateCommand
+    module ValidCommand
 
-      attr_reader :clirb
-
-      def initialize(argv, stdout = nil)
+      def initialize(argv, stdout = nil, stderr = nil)
         @argv   = argv
         @stdout = stdout || $stdout
-        @clirb  = GGem::CLIRB.new
+        @stderr = stderr || $stderr
+
+        @clirb = GGem::CLIRB.new
       end
+
+      def clirb; @clirb; end
 
       def run
         @clirb.parse!(@argv)
+      end
+
+    end
+
+    class GenerateCommand
+      include ValidCommand
+
+      def run
+        super
         begin
           require 'ggem/gem'
           path = GGem::Gem.new(Dir.pwd, @clirb.args.first).save!.path
@@ -113,6 +130,117 @@ module GGem
       def help
         "Usage: ggem generate [options] GEM-NAME\n\n" \
         "Options: #{@clirb}"
+      end
+
+    end
+
+    module ExecuteCommand
+      private
+
+      def execute(success_msg, &cmd_block)
+        cmd, status, output = cmd_block.call
+        if ENV['DEBUG']
+          @stdout.puts cmd
+          @stdout.puts output
+        end
+        @stdout.puts success_msg
+      end
+    end
+
+    module GemspecCommand
+      def self.included(receiver)
+        receiver.send(:include, ValidCommand)
+        receiver.send(:include, ExecuteCommand)
+        receiver.send(:include, InstanceMethods)
+      end
+
+      module InstanceMethods
+        def initialize(*args)
+          super
+
+          require 'ggem/gemspec'
+          begin
+            @spec = GGem::Gemspec.new(Dir.pwd)
+          rescue GGem::Gemspec::NotFoundError => exception
+            @stderr.puts "There are no gemspecs at #{Dir.pwd}"
+            raise CommandExitError
+          end
+        end
+
+        private
+
+        def execute_build
+          execute("#{@spec.name} #{@spec.version} built to #{@spec.gem_file}") do
+            @spec.run_build_cmd
+          end
+        end
+
+        def execute(*args, &block)
+          begin
+            super
+          rescue GGem::Gemspec::CmdError => exception
+            @stderr.puts exception.message
+            raise CommandExitError
+          end
+        end
+
+      end
+    end
+
+    class BuildCommand
+      include GemspecCommand
+
+      def run
+        super
+        execute_build
+      end
+
+      def help
+        "Usage: ggem build [options]\n\n" \
+        "Options: #{@clirb}\n" \
+        "Description:\n" \
+        "  Build #{@spec.gem_file_name} into the " \
+           "#{GGem::Gemspec::BUILD_TO_DIRNAME} directory"
+      end
+
+    end
+
+    class InstallCommand
+      include GemspecCommand
+
+      def run
+        super
+        execute_build
+        execute("#{@spec.name} #{@spec.version} installed to system gems") do
+          @spec.run_install_cmd
+        end
+      end
+
+      def help
+        "Usage: ggem install [options]\n\n" \
+        "Options: #{@clirb}\n" \
+        "Description:\n" \
+        "  Build and install #{@spec.gem_file_name} into system gems"
+      end
+
+    end
+
+    class PushCommand
+      include GemspecCommand
+
+      def run
+        super
+        execute_build
+        execute("#{@spec.name} #{@spec.version} pushed to #{@spec.push_host}") do
+          @spec.run_push_cmd
+        end
+      end
+
+      def help
+        "Usage: ggem push [options]\n\n" \
+        "Options: #{@clirb}\n" \
+        "Description:\n" \
+        "  Push built #{@spec.gem_file_name} to #{@spec.push_host}"
       end
 
     end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'ggem/cli'
 
 require 'ggem/gem'
+require 'ggem/gemspec'
 
 class GGem::CLI
 
@@ -28,12 +29,15 @@ class GGem::CLI
     end
 
     should "know its commands" do
-      assert_equal 2, COMMANDS.size
+      assert_equal 5, COMMANDS.size
 
       assert_instance_of InvalidCommand, COMMANDS[Factory.string]
 
       assert_equal GenerateCommand, COMMANDS['generate']
       assert_equal GenerateCommand, COMMANDS['g']
+      assert_equal BuildCommand,    COMMANDS['build']
+      assert_equal InstallCommand,  COMMANDS['install']
+      assert_equal PushCommand,     COMMANDS['push']
     end
 
   end
@@ -238,7 +242,36 @@ class GGem::CLI
 
   end
 
-  class GenerateCommandTests < UnitTests
+  class IOCommandTests < UnitTests
+    setup do
+      @stdout, @stderr = IOSpy.new, IOSpy.new
+    end
+    subject{ @cmd }
+
+  end
+
+  class ValidCommandTests < IOCommandTests
+    desc "ValidCommand"
+    setup do
+      @command_class = Class.new{ include ValidCommand }
+      @args = Factory.integer(3).times.map{ Factory.string }
+      @cmd  = @command_class.new(@args, @stdout, @stderr)
+    end
+
+    should have_imeths :clirb, :run
+
+    should "know its CLI.RB" do
+      assert_instance_of GGem::CLIRB, subject.clirb
+    end
+
+    should "parse its args when run" do
+      subject.run
+      assert_equal @args, subject.clirb.args
+    end
+
+  end
+
+  class GenerateCommandTests < IOCommandTests
     desc "GenerateCommand"
     setup do
       @name = Factory.string
@@ -258,12 +291,9 @@ class GGem::CLI
       @command_class = GenerateCommand
       @cmd = @command_class.new([@name], @stdout)
     end
-    subject{ @cmd }
 
-    should have_readers :clirb
-
-    should "know its CLI.RB" do
-      assert_instance_of GGem::CLIRB, subject.clirb
+    should "be a valid command" do
+      assert_kind_of ValidCommand, subject
     end
 
     should "know its help" do
@@ -272,10 +302,8 @@ class GGem::CLI
       assert_equal exp, subject.help
     end
 
-    should "parse its args and save a gem when run" do
+    should "save a gem when run" do
       subject.run
-
-      assert_equal [@name], subject.clirb.args
 
       assert_equal [@path, @name], @gem_new_called_with
       assert_true @gem_spy.save_called
@@ -297,6 +325,183 @@ class GGem::CLI
       exp = "GEM-NAME must be provided"
       assert_equal exp, err.message
       assert_not_empty err.backtrace
+    end
+
+  end
+
+  class GemspecCommandTests < IOCommandTests
+    desc "GemspecCommand"
+    setup do
+      @gem1_root_path = TEST_SUPPORT_PATH.join('gem1')
+      Assert.stub(Dir, :pwd){ @gem1_root_path}
+
+      @command_class = Class.new{ include GemspecCommand }
+      @args = Factory.integer(3).times.map{ Factory.string }
+      @cmd  = @command_class.new(@args, @stdout, @stderr)
+    end
+
+    should "be a valid, execute command" do
+      assert_kind_of ValidCommand,   subject
+      assert_kind_of ExecuteCommand, subject
+    end
+
+    should "build a new gemspec at the current pwd root" do
+      gemspec_new_called_with = nil
+      Assert.stub(GGem::Gemspec, :new){ |*args| gemspec_new_called_with = args }
+
+      @command_class.new(@args, @stdout, @stderr)
+      assert_equal [Dir.pwd], gemspec_new_called_with
+    end
+
+    should "complain if no gemspec file can be found at the current pwd" do
+      root = Factory.path
+      Assert.stub(Dir, :pwd){ root }
+
+      assert_raises(CommandExitError) do
+        @command_class.new(@args, @stdout, @stderr)
+      end
+      exp = "There are no gemspecs at #{Dir.pwd}\n"
+      assert_equal exp, @stderr.read
+    end
+
+  end
+
+  class GemspecSpyTests < IOCommandTests
+    setup do
+      @root_path = Factory.path
+      Assert.stub(Dir, :pwd){ @root_path }
+
+      @spec_spy = nil
+      Assert.stub(GGem::Gemspec, :new){ |*args| @spec_spy = GemspecSpy.new(*args) }
+    end
+
+  end
+
+  class BuildCommandTests < GemspecSpyTests
+    desc "BuildCommand"
+    setup do
+      @command_class = BuildCommand
+      @cmd = @command_class.new([], @stdout, @stderr)
+    end
+
+    should "be a gemspec command" do
+      assert_kind_of GemspecCommand, subject
+    end
+
+    should "know its help" do
+      exp = "Usage: ggem build [options]\n\n" \
+            "Options: #{subject.clirb}\n" \
+            "Description:\n" \
+            "  Build #{@spec_spy.gem_file_name} into the " \
+               "#{GGem::Gemspec::BUILD_TO_DIRNAME} directory"
+      assert_equal exp, subject.help
+    end
+
+    should "call the spec's run build cmd when run" do
+      ENV['DEBUG'] = [nil, '1'].choice
+      subject.run
+
+      assert_true @spec_spy.run_build_cmd_called
+
+      exp = ENV['DEBUG'] == '1' ? "build\nbuild cmd was run\n" : ''
+      exp += "#{@spec_spy.name} #{@spec_spy.version} built to #{@spec_spy.gem_file}\n"
+      assert_equal exp, @stdout.read
+
+      ENV['DEBUG'] = nil
+    end
+
+    should "handle cmd errors when run" do
+      err_msg = Factory.string
+      Assert.stub(@spec_spy, :run_build_cmd){ raise GGem::Gemspec::CmdError, err_msg }
+
+      assert_raises(CommandExitError){ subject.run }
+      assert_equal "#{err_msg}\n", @stderr.read
+    end
+
+  end
+
+  class InstallCommandTests < GemspecSpyTests
+    desc "InstallCommand"
+    setup do
+      @command_class = InstallCommand
+      @cmd = @command_class.new([], @stdout, @stderr)
+    end
+
+    should "be a gemspec command" do
+      assert_kind_of GemspecCommand, subject
+    end
+
+    should "know its help" do
+      exp = "Usage: ggem install [options]\n\n" \
+            "Options: #{subject.clirb}\n" \
+            "Description:\n" \
+            "  Build and install #{@spec_spy.gem_file_name} into system gems"
+      assert_equal exp, subject.help
+    end
+
+    should "call the spec's run build/install cmds when run" do
+      ENV['DEBUG'] = [nil, '1'].choice
+      subject.run
+
+      assert_true @spec_spy.run_build_cmd_called
+      assert_true @spec_spy.run_install_cmd_called
+
+      exp = ENV['DEBUG'] == '1' ? "install\ninstall cmd was run\n" : ''
+      exp += "#{@spec_spy.name} #{@spec_spy.version} installed to system gems\n"
+      assert_includes exp, @stdout.read
+
+      ENV['DEBUG'] = nil
+    end
+
+    should "handle cmd errors when run" do
+      err_msg = Factory.string
+      Assert.stub(@spec_spy, :run_install_cmd){ raise GGem::Gemspec::CmdError, err_msg }
+
+      assert_raises(CommandExitError){ subject.run }
+      assert_equal "#{err_msg}\n", @stderr.read
+    end
+
+  end
+
+  class PushCommandTests < GemspecSpyTests
+    desc "PushCommand"
+    setup do
+      @command_class = PushCommand
+      @cmd = @command_class.new([], @stdout, @stderr)
+    end
+
+    should "be a gemspec command" do
+      assert_kind_of GemspecCommand, subject
+    end
+
+    should "know its help" do
+      exp = "Usage: ggem push [options]\n\n" \
+            "Options: #{subject.clirb}\n" \
+            "Description:\n" \
+            "  Push built #{@spec_spy.gem_file_name} to #{@spec_spy.push_host}"
+      assert_equal exp, subject.help
+    end
+
+    should "call the spec's run build/push cmds when run" do
+      ENV['DEBUG'] = [nil, '1'].choice
+      subject.run
+
+      assert_true @spec_spy.run_build_cmd_called
+      assert_true @spec_spy.run_push_cmd_called
+
+      exp = ENV['DEBUG'] == '1' ? "push\npush cmd was run\n" : ''
+      exp += "#{@spec_spy.name} #{@spec_spy.version} pushed to #{@spec_spy.push_host}\n"
+      assert_includes exp, @stdout.read
+
+      ENV['DEBUG'] = nil
+    end
+
+    should "handle cmd errors when run" do
+      err_msg = Factory.string
+      Assert.stub(@spec_spy, :run_push_cmd){ raise GGem::Gemspec::CmdError, err_msg }
+
+      assert_raises(CommandExitError){ subject.run }
+      assert_equal "#{err_msg}\n", @stderr.read
     end
 
   end
@@ -371,6 +576,50 @@ class GGem::CLI
     def path
       @path ||= Factory.path
     end
+  end
+
+  class GemspecSpy
+    attr_reader :name, :version, :push_host
+    attr_reader :run_build_cmd_called, :run_install_cmd_called, :run_push_cmd_called
+
+    def initialize(root_path)
+      @root      = Pathname.new(File.expand_path(root_path))
+      @name      = Factory.string
+      @version   = Factory.string
+      @push_host = Factory.url
+
+      @run_build_cmd_called   = false
+      @run_install_cmd_called = false
+      @run_push_cmd_called    = false
+    end
+
+    def path
+      @root.join("#{self.name}.gemspec")
+    end
+
+    def gem_file_name
+      "#{self.name}-#{self.version}.gem"
+    end
+
+    def gem_file
+      File.join(GGem::Gemspec::BUILD_TO_DIRNAME, self.gem_file_name)
+    end
+
+    def run_build_cmd
+      @run_build_cmd_called = true
+      ['build', 0, 'build cmd was run']
+    end
+
+    def run_install_cmd
+      @run_install_cmd_called = true
+      ['install', 0, 'install cmd was run']
+    end
+
+    def run_push_cmd
+      @run_push_cmd_called = true
+      ['push', 0, 'push cmd was run']
+    end
+
   end
 
 end


### PR DESCRIPTION
These commands all build a gemspec object and call the corresponding
run cmd method.  In the case of install and push, they both first
build the gemspec before running their own cmd methods.

Each sub command outputs a success msg on success and outputs any
command stderr output on failure.  If in debug mode, both the cmd str
and any stdout value are also outputted.

Note: this introduces some cli sub command help mixins.  The valid
command mixin is for use on all non invalid commands and commonizes
the argv, stdout/err and clirb handling.  The execute command mixin
commonizes running methods that call system commands and handles
mapping the system command output to stdout.  Finally, the
gemspec command mixin commonizes building a gemspec and handling
mapping gemspec system cmd errors to stderr.  It also commonizes
the logic for running the build command since it is used in all
gemspec commands.

This is all part of updating GGem to implement gem handling sub
commands.  The goal is to no longer need bundler/rake to handle gems
but still have a similarly nice api/scripts for gem operations.

@jcredding ready for review.