### PR TITLE
model a git repo; add init cmd behavior; use in template generate

### DIFF
--- a/ggem.gemspec
+++ b/ggem.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.0"])
 
-  gem.add_dependency("scmd", ["~> 3.0.1"])
+  gem.add_dependency("much-plugin", ["~> 0.1.0"])
+  gem.add_dependency("scmd",        ["~> 3.0.1"])
 
 end

--- a/lib/ggem/gem.rb
+++ b/lib/ggem/gem.rb
@@ -13,8 +13,7 @@ module GGem
     end
 
     def save!
-      Template.new(self).tap{ |t| t.save; t.init }
-      self
+      Template.new(self).save
     end
 
     def path; File.join(@root_path, @name); end
@@ -41,7 +40,7 @@ module GGem
       name.gsub(*und_camelcs).gsub(*rm_dup_und).sub(*rm_lead_und).downcase
     end
 
-    def transform_name(conditions={}, &block)
+    def transform_name(conditions = {}, &block)
       n = (block ? block.call(self.name) : self.name)
       conditions.each do |on, glue|
         if (a = n.split(on)).size > 1

--- a/lib/ggem/gemspec.rb
+++ b/lib/ggem/gemspec.rb
@@ -30,29 +30,29 @@ module GGem
     end
 
     def run_build_cmd
-      run_cmd("gem build --verbose #{@path}", BuildError).tap do |c|
+      run_cmd("gem build --verbose #{@path}").tap do
         gem_path = @root.join(@gem_file_name)
-        run_cmd("mkdir -p #{@built_gem_path.dirname}", BuildError)
-        run_cmd("mv #{gem_path} #{@built_gem_path}",   BuildError)
+        run_cmd("mkdir -p #{@built_gem_path.dirname}")
+        run_cmd("mv #{gem_path} #{@built_gem_path}")
       end
     end
 
     def run_install_cmd
-      run_cmd("gem install #{@built_gem_path}", InstallError)
+      run_cmd("gem install #{@built_gem_path}")
     end
 
     def run_push_cmd
-      run_cmd("gem push #{@built_gem_path} --host #{@push_host}", PushError)
+      run_cmd("gem push #{@built_gem_path} --host #{@push_host}")
     end
 
     private
 
-    def run_cmd(cmd_string, exception_class)
+    def run_cmd(cmd_string)
       cmd = Scmd.new(cmd_string)
       cmd.run
       if !cmd.success?
-        raise exception_class, "#{cmd_string}\n" \
-                               "#{cmd.stderr.empty? ? cmd.stdout : cmd.stderr}"
+        raise CmdError, "#{cmd_string}\n" \
+                        "#{cmd.stderr.empty? ? cmd.stdout : cmd.stderr}"
       end
       [cmd_string, cmd.exitstatus, cmd.stdout]
     end
@@ -78,9 +78,6 @@ module GGem
     NotFoundError = Class.new(ArgumentError)
     LoadError     = Class.new(ArgumentError)
     CmdError      = Class.new(RuntimeError)
-    BuildError    = Class.new(CmdError)
-    InstallError  = Class.new(CmdError)
-    PushError     = Class.new(CmdError)
 
   end
 

--- a/lib/ggem/git_repo.rb
+++ b/lib/ggem/git_repo.rb
@@ -1,0 +1,38 @@
+require 'pathname'
+require 'scmd'
+
+module GGem
+
+  class GitRepo
+
+    attr_reader :path
+
+    def initialize(repo_path)
+      @path = Pathname.new(File.expand_path(repo_path))
+    end
+
+    def run_init_cmd
+      run_cmd("git init").tap do
+        run_cmd("git add --all && git add -f *.gitkeep")
+      end
+    end
+
+    private
+
+    def run_cmd(cmd_string)
+      cmd_string = "cd #{@path} && #{cmd_string}"
+      cmd = Scmd.new(cmd_string)
+      cmd.run
+      if !cmd.success?
+        raise CmdError, "#{cmd_string}\n" \
+                        "#{cmd.stderr.empty? ? cmd.stdout : cmd.stderr}"
+      end
+      [cmd_string, cmd.exitstatus, cmd.stdout]
+    end
+
+    NotFoundError = Class.new(ArgumentError)
+    CmdError      = Class.new(RuntimeError)
+
+  end
+
+end

--- a/lib/ggem/template.rb
+++ b/lib/ggem/template.rb
@@ -35,13 +35,6 @@ module GGem
       save_empty_file('tmp/.gitkeep')
     end
 
-    def init
-      cmd = "cd #{@gem.path} &&"\
-            " git init && git add --all &&"\
-            " git add -f log/.gitkeep && git add -f tmp/.gitkeep"
-      `#{cmd}`
-    end
-
     private
 
     def save_folder(relative_path=nil)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,5 +12,3 @@ TEST_SUPPORT_PATH = ROOT_PATH.join('test/support')
 require 'pry'
 
 require 'test/support/factory'
-
-ENV['SCMD_TEST_MODE'] = '1'

--- a/test/system/ggem_tests.rb
+++ b/test/system/ggem_tests.rb
@@ -38,11 +38,6 @@ module GGem
     should create_paths(NS_UNDER.new)
     should create_paths(NS_HYPHEN.new)
 
-    should "init a git repo in the gem path" do
-      exp_path = File.join(TMP_PATH, NS_SIMPLE.new.name, '.git')
-      assert File.exists?(exp_path), ".git repo config doesn't exist"
-    end
-
   end
 
 end

--- a/test/unit/gemspec_tests.rb
+++ b/test/unit/gemspec_tests.rb
@@ -1,6 +1,7 @@
 require "assert"
 require "ggem/gemspec"
 
+require 'scmd'
 require 'ggem/version'
 
 class GGem::Gemspec
@@ -28,9 +29,6 @@ class GGem::Gemspec
       assert subject::NotFoundError < ArgumentError
       assert subject::LoadError < ArgumentError
       assert subject::CmdError < RuntimeError
-      assert subject::BuildError < CmdError
-      assert subject::InstallError < CmdError
-      assert subject::PushError < CmdError
     end
 
   end
@@ -93,6 +91,8 @@ class GGem::Gemspec
 
   class CmdTests < InitTests
     setup do
+      ENV['SCMD_TEST_MODE'] = '1'
+
       @exp_build_path = @gem1_root_path.join(subject.gem_file_name)
       @exp_pkg_path   = @gem1_root_path.join(@gemspec_class::BUILD_TO_DIRNAME, subject.gem_file_name)
 
@@ -101,6 +101,7 @@ class GGem::Gemspec
     end
     teardown do
       Scmd.reset
+      ENV.delete('SCMD_TEST_MODE')
     end
 
   end
@@ -137,7 +138,7 @@ class GGem::Gemspec
       rescue StandardError => err
       end
 
-      assert_kind_of BuildError, err
+      assert_kind_of CmdError, err
       exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
       assert_equal exp, err.message
     end
@@ -172,7 +173,7 @@ class GGem::Gemspec
       rescue StandardError => err
       end
 
-      assert_kind_of InstallError, err
+      assert_kind_of CmdError, err
       exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
       assert_equal exp, err.message
     end
@@ -207,7 +208,7 @@ class GGem::Gemspec
       rescue StandardError => err
       end
 
-      assert_kind_of PushError, err
+      assert_kind_of CmdError, err
       exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
       assert_equal exp, err.message
     end

--- a/test/unit/git_repo_tests.rb
+++ b/test/unit/git_repo_tests.rb
@@ -1,0 +1,91 @@
+require "assert"
+require "ggem/git_repo"
+
+require 'scmd'
+
+class GGem::GitRepo
+
+  class UnitTests < Assert::Context
+    desc "GGem::GitRepo"
+    setup do
+      @git_repo_class = GGem::GitRepo
+    end
+    subject{ @git_repo_class }
+
+    should "know its exceptions" do
+      assert subject::NotFoundError < ArgumentError
+      assert subject::CmdError < RuntimeError
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @repo_path = TEST_SUPPORT_PATH.join('gem1')
+      @repo = @git_repo_class.new(@repo_path)
+    end
+    subject{ @repo }
+
+    should have_readers :path
+    should have_imeths :run_init_cmd
+
+    should "know its path" do
+      assert_equal @repo_path, subject.path
+    end
+
+  end
+
+  class CmdTests < InitTests
+    setup do
+      ENV['SCMD_TEST_MODE'] = '1'
+
+      @cmd_spy = nil
+      Scmd.reset
+    end
+    teardown do
+      Scmd.reset
+      ENV.delete('SCMD_TEST_MODE')
+    end
+
+  end
+
+  class RunInitCmdTests < CmdTests
+    desc "`run_init_cmd`"
+    setup do
+      @exp_cmds_run = [
+        "cd #{@repo_path} && git init",
+        "cd #{@repo_path} && git add --all && git add -f *.gitkeep"
+      ]
+    end
+
+    should "run a system cmd to init the repo and add any existing files" do
+      cmd_str, exitstatus, stdout = subject.run_init_cmd
+      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
+
+      assert_equal Scmd.calls.first.cmd_str,        cmd_str
+      assert_equal Scmd.calls.first.cmd.exitstatus, exitstatus
+      assert_equal Scmd.calls.first.cmd.stdout,     stdout
+    end
+
+    should "complain if any system cmds are not successful" do
+      err_cmd_str = @exp_cmds_run.choice
+      Scmd.add_command(err_cmd_str) do |cmd|
+        cmd.exitstatus = 1
+        cmd.stderr     = Factory.string
+        @cmd_spy       = cmd
+      end
+      err = nil
+      begin
+        subject.run_init_cmd
+      rescue StandardError => err
+      end
+
+      assert_kind_of CmdError, err
+      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
+      assert_equal exp, err.message
+    end
+
+  end
+
+end


### PR DESCRIPTION
This models a git repo and the associated system cmds to initialize
it.  The init behavior is then applied to the generate command
logic and the previous template init logic is removed as it is
no longer needed.

The git repo will also be used in some future CLI sub commands.
Specifically tagging and push-with-tags logic will be used in a
coming gem "release" sub command.

Note: this also cleans up a few things on the gemspec model that
become apparent when adding the git repo model:

* remove the tap block arg - it isn't used and was incorrect
* remove the command specific exceptions and usage - there really
  isn't any value to them right now and they weren't being used and
  just added technical debt

@jcredding ready for review.