### PR TITLE
git repo: add API for running tag and push related system commands

### DIFF
--- a/lib/ggem/git_repo.rb
+++ b/lib/ggem/git_repo.rb
@@ -17,6 +17,28 @@ module GGem
       end
     end
 
+    def run_validate_clean_cmd
+      run_cmd("git diff --exit-code")
+    end
+
+    def run_validate_committed_cmd
+      run_cmd("git diff-index --quiet --cached HEAD")
+    end
+
+    def run_push_cmd
+      run_cmd("git push").tap do
+        run_cmd("git push --tags")
+      end
+    end
+
+    def run_add_version_tag_cmd(version, tag)
+      run_cmd("git tag -a -m \"Version #{version}\" #{tag}")
+    end
+
+    def run_rm_tag_cmd(tag)
+      run_cmd("git tag -d #{tag}")
+    end
+
     private
 
     def run_cmd(cmd_string)

--- a/test/support/cmd_tests_helpers.rb
+++ b/test/support/cmd_tests_helpers.rb
@@ -1,0 +1,53 @@
+require 'much-plugin'
+require 'scmd'
+
+module GGem
+
+  module CmdTestsHelpers
+    include MuchPlugin
+
+    plugin_included do
+      setup do
+        ENV['SCMD_TEST_MODE'] = '1'
+
+        @cmd_spy = nil
+        Scmd.reset
+
+        @exp_cmds_run = []
+      end
+      teardown do
+        Scmd.reset
+        ENV.delete('SCMD_TEST_MODE')
+      end
+
+      private
+
+      def assert_exp_cmds_run(&run_cmd_block)
+        cmd_str, exitstatus, stdout = run_cmd_block.call
+        assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
+
+        assert_equal Scmd.calls.first.cmd_str,        cmd_str
+        assert_equal Scmd.calls.first.cmd.exitstatus, exitstatus
+        assert_equal Scmd.calls.first.cmd.stdout,     stdout
+      end
+
+      def assert_exp_cmds_error(cmd_error_class, &run_cmd_block)
+        err_cmd_str = @exp_cmds_run.choice
+        Scmd.add_command(err_cmd_str) do |cmd|
+          cmd.exitstatus = 1
+          cmd.stderr     = Factory.string
+          @cmd_spy       = cmd
+        end
+        err = nil
+        begin; run_cmd_block.call; rescue StandardError => err; end
+
+        assert_kind_of cmd_error_class, err
+        exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
+        assert_equal exp, err.message
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/gemspec_tests.rb
+++ b/test/unit/gemspec_tests.rb
@@ -1,8 +1,8 @@
 require "assert"
 require "ggem/gemspec"
 
-require 'scmd'
 require 'ggem/version'
+require 'test/support/cmd_tests_helpers'
 
 class GGem::Gemspec
 
@@ -90,18 +90,10 @@ class GGem::Gemspec
   end
 
   class CmdTests < InitTests
+    include GGem::CmdTestsHelpers
     setup do
-      ENV['SCMD_TEST_MODE'] = '1'
-
       @exp_build_path = @gem1_root_path.join(subject.gem_file_name)
       @exp_pkg_path   = @gem1_root_path.join(@gemspec_class::BUILD_TO_DIRNAME, subject.gem_file_name)
-
-      @cmd_spy = nil
-      Scmd.reset
-    end
-    teardown do
-      Scmd.reset
-      ENV.delete('SCMD_TEST_MODE')
     end
 
   end
@@ -117,30 +109,11 @@ class GGem::Gemspec
     end
 
     should "run system cmds to build the gem" do
-      cmd_str, exitstatus, stdout = subject.run_build_cmd
-      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
-
-      assert_equal Scmd.calls.first.cmd_str,        cmd_str
-      assert_equal Scmd.calls.first.cmd.exitstatus, exitstatus
-      assert_equal Scmd.calls.first.cmd.stdout,     stdout
+      assert_exp_cmds_run{ subject.run_build_cmd }
     end
 
     should "complain if any system cmds are not successful" do
-      err_cmd_str = @exp_cmds_run.choice
-      Scmd.add_command(err_cmd_str) do |cmd|
-        cmd.exitstatus = 1
-        cmd.stderr     = Factory.string
-        @cmd_spy       = cmd
-      end
-      err = nil
-      begin
-        subject.run_build_cmd
-      rescue StandardError => err
-      end
-
-      assert_kind_of CmdError, err
-      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
-      assert_equal exp, err.message
+      assert_exp_cmds_error(CmdError){ subject.run_build_cmd }
     end
 
   end
@@ -152,30 +125,11 @@ class GGem::Gemspec
     end
 
     should "run a system cmd to install the gem" do
-      cmd_str, exitstatus, stdout = subject.run_install_cmd
-      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
-
-      assert_equal Scmd.calls.last.cmd_str,        cmd_str
-      assert_equal Scmd.calls.last.cmd.exitstatus, exitstatus
-      assert_equal Scmd.calls.last.cmd.stdout,     stdout
+      assert_exp_cmds_run{ subject.run_install_cmd }
     end
 
     should "complain if the system cmd is not successful" do
-      err_cmd_str = @exp_cmds_run.choice
-      Scmd.add_command(err_cmd_str) do |cmd|
-        cmd.exitstatus = 1
-        cmd.stderr     = Factory.string
-        @cmd_spy       = cmd
-      end
-      err = nil
-      begin
-        subject.run_install_cmd
-      rescue StandardError => err
-      end
-
-      assert_kind_of CmdError, err
-      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
-      assert_equal exp, err.message
+      assert_exp_cmds_error(CmdError){ subject.run_install_cmd }
     end
 
   end
@@ -187,30 +141,11 @@ class GGem::Gemspec
     end
 
     should "run a system cmd to push the gem to the push host" do
-      cmd_str, exitstatus, stdout = subject.run_push_cmd
-      assert_equal @exp_cmds_run, Scmd.calls.map(&:cmd_str)
-
-      assert_equal Scmd.calls.last.cmd_str,        cmd_str
-      assert_equal Scmd.calls.last.cmd.exitstatus, exitstatus
-      assert_equal Scmd.calls.last.cmd.stdout,     stdout
+      assert_exp_cmds_run{ subject.run_push_cmd }
     end
 
     should "complain if the system cmd is not successful" do
-      err_cmd_str = @exp_cmds_run.choice
-      Scmd.add_command(err_cmd_str) do |cmd|
-        cmd.exitstatus = 1
-        cmd.stderr     = Factory.string
-        @cmd_spy       = cmd
-      end
-      err = nil
-      begin
-        subject.run_push_cmd
-      rescue StandardError => err
-      end
-
-      assert_kind_of CmdError, err
-      exp = "#{@cmd_spy.cmd_str}\n#{@cmd_spy.stderr}"
-      assert_equal exp, err.message
+      assert_exp_cmds_error(CmdError){ subject.run_push_cmd }
     end
 
   end


### PR DESCRIPTION
These commands will be used in the comming "tag" CLI sub command.
These methods just call the raw system commands to validate, tag
and push on the repo.

Note: I reworked the cmd tests in the gemspec tests to try an commonize
a bunch of boilerplate cmd test logic that I also needed for the
git repo tests.

@jcredding ready for review.