### PR TITLE
add 'tag' CLI sub command

### DIFF
--- a/lib/ggem/gemspec.rb
+++ b/lib/ggem/gemspec.rb
@@ -9,7 +9,7 @@ module GGem
     DEFAULT_PUSH_HOST  = 'https://rubygems.org'.freeze
     BUILD_TO_DIRNAME   = 'pkg'.freeze
 
-    attr_reader :path, :name, :version
+    attr_reader :path, :name, :version, :version_tag
     attr_reader :gem_file_name, :gem_file, :push_host
 
     def initialize(root_path)
@@ -18,9 +18,10 @@ module GGem
       @path = Pathname.new(Dir[File.join(@root, "{,*}.gemspec")].first.to_s)
       raise NotFoundError unless @path.exist?
 
-      @spec    = load_gemspec(@path)
-      @name    = @spec.name
-      @version = @spec.version
+      @spec        = load_gemspec(@path)
+      @name        = @spec.name
+      @version     = @spec.version
+      @version_tag = "v#{@version}"
 
       @gem_file_name  = "#{@name}-#{@version}.gem"
       @gem_file       = File.join(BUILD_TO_DIRNAME, @gem_file_name)

--- a/test/unit/gemspec_tests.rb
+++ b/test/unit/gemspec_tests.rb
@@ -41,7 +41,7 @@ class GGem::Gemspec
     end
     subject{ @spec }
 
-    should have_readers :path, :name, :version
+    should have_readers :path, :name, :version, :version_tag
     should have_readers :gem_file_name, :gem_file, :push_host
     should have_imeths :run_build_cmd, :run_install_cmd, :run_push_cmd
 
@@ -49,8 +49,9 @@ class GGem::Gemspec
       exp = @gem1_root_path.join('gem1.gemspec')
       assert_equal exp, subject.path
 
-      assert_equal 'gem1',  subject.name
-      assert_equal '0.1.0', subject.version.to_s
+      assert_equal 'gem1',   subject.name
+      assert_equal '0.1.0',  subject.version.to_s
+      assert_equal 'v0.1.0', subject.version_tag
 
       exp = "#{subject.name}-#{subject.version}.gem"
       assert_equal exp, subject.gem_file_name


### PR DESCRIPTION
The command tags the commit with the spec's version information and
pushed any commits/tags.  This will be part of the coming 'release'
macro sub command that will tag the gem version and push the gem
to the push host.

This command requires the full string to tag the commit with.  I
chose to call the the `version_tag` and added this info to the
gemspec model so it would be centrally located alongside the raw
version info.

The tag command is both a git repo command and a gemspec command
in that it operates on a git repo object for the gem using the
spec's information.  I had to rework a couple things to make this
work as this is the first sub command that is both a repo command
and a spec command:

* I renamed the "execute" stuff to "notify cmd" naming.  This better
  describes the functions as they are about running system commands
  and notifying the CLI stdout/stderr.
* I broke out the base command running logic into a `cmd` function
  b/c the tag command has to do manual stdout/stderr notification
  b/c it doing a bunch of small system commands and needs very custom
  orchestration of those system commands and the related output to
  the CLI.
* I had to break out some CLI test contexts into mixins b/c the
  tag command had to mixin both the git repo spy and the gemspec spy
  contexts as it requires both.  I updated the existing tests
  accordingly.

@jcredding ready for review.