### PR TITLE
cli: rework the install/push commands to compose the build command

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -235,12 +235,6 @@ module GGem
 
         private
 
-        def notify_build
-          notify("#{@spec.name} #{@spec.version} built to #{@spec.gem_file}") do
-            @spec.run_build_cmd
-          end
-        end
-
         def notify(*args, &block)
           begin
             super
@@ -258,7 +252,9 @@ module GGem
 
       def run
         super
-        notify_build
+        notify("#{@spec.name} #{@spec.version} built to #{@spec.gem_file}") do
+          @spec.run_build_cmd
+        end
       end
 
       def help
@@ -274,9 +270,14 @@ module GGem
     class InstallCommand
       include GemspecCommand
 
+      def initialize(*args)
+        super
+        @build_command = BuildCommand.new(*args)
+      end
+
       def run
         super
-        notify_build
+        @build_command.run
         notify("#{@spec.name} #{@spec.version} installed to system gems") do
           @spec.run_install_cmd
         end
@@ -294,9 +295,14 @@ module GGem
     class PushCommand
       include GemspecCommand
 
+      def initialize(*args)
+        super
+        @build_command = BuildCommand.new(*args)
+      end
+
       def run
         super
-        notify_build
+        @build_command.run
 
         @stdout.puts "Pushing #{@spec.gem_file_name} to #{@spec.push_host}..."
         notify("#{@spec.gem_file_name} received.") do


### PR DESCRIPTION
This makes their implementation similar to the release command
which composes both the tag and the push commands.  It also removes
the need for the `notify_build` helper method.  This implementation
will scale better b/c any behavior or output added to the build
command will be used in the install/push commands.  This implementation
is the intent.

This also updates some tests for some CLI output and help messages.
These should have been done in the previous hotfix but were missed
b/c I forgot to run the test suite.

@jcredding ready for review.