### PR TITLE
gemspec template updates

### DIFF
--- a/lib/ggem/template_file/gemspec.erb
+++ b/lib/ggem/template_file/gemspec.erb
@@ -8,9 +8,9 @@ Gem::Specification.new do |gem|
   gem.version     = <%= @gem.module_name %>::VERSION
   gem.authors     = ["TODO: authors"]
   gem.email       = ["TODO: emails"]
-  gem.description = %q{TODO: Write a gem description}
-  gem.summary     = %q{TODO: Write a gem summary}
-  gem.homepage    = "http://github.com/__/<%= @gem.name %>"
+  gem.summary     = "TODO: Write a gem summary"
+  gem.description = "TODO: Write a gem description"
+  gem.homepage    = "TODO: homepage"
   gem.license     = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15"])
-  # TODO: gem.add_dependency("gem-name", ["~> 0.0"])
+  gem.add_development_dependency("assert", ["~> 2.15.0"])
+  # TODO: gem.add_dependency("gem-name", ["~> 0.0.0"])
 
 end


### PR DESCRIPTION
Trying to keep things up-to-date.  There are a few changed here:

* use straightforward strings for summary/description
* reorder to put summary before description
* switch homepage to a TODO so rubygems will warn if you don't update it
* use vanity versions on the generated gem dependencies

@jcredding not much to review but are you cool with all this?