### PR TITLE
cli: first letter alias the other sub commands

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -17,10 +17,15 @@ module GGem
       h['generate'] = GenerateCommand
       h['g']        = GenerateCommand
       h['build']    = BuildCommand
+      h['b']        = BuildCommand
       h['install']  = InstallCommand
+      h['i']        = InstallCommand
       h['push']     = PushCommand
+      h['p']        = PushCommand
       h['tag']      = TagCommand
+      h['t']        = TagCommand
       h['release']  = ReleaseCommand
+      h['r']        = ReleaseCommand
     end
 
     def self.run(args)

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -31,17 +31,22 @@ class GGem::CLI
     end
 
     should "know its commands" do
-      assert_equal 7, COMMANDS.size
+      assert_equal 12, COMMANDS.size
 
       assert_instance_of InvalidCommand, COMMANDS[Factory.string]
 
       assert_equal GenerateCommand, COMMANDS['generate']
       assert_equal GenerateCommand, COMMANDS['g']
       assert_equal BuildCommand,    COMMANDS['build']
+      assert_equal BuildCommand,    COMMANDS['b']
       assert_equal InstallCommand,  COMMANDS['install']
+      assert_equal InstallCommand,  COMMANDS['i']
       assert_equal PushCommand,     COMMANDS['push']
+      assert_equal PushCommand,     COMMANDS['p']
       assert_equal TagCommand,      COMMANDS['tag']
+      assert_equal TagCommand,      COMMANDS['t']
       assert_equal ReleaseCommand,  COMMANDS['release']
+      assert_equal ReleaseCommand,  COMMANDS['r']
     end
 
   end


### PR DESCRIPTION
Because why not?  If it is good enough for 'generate' it is good
enough for the others.

@jcredding any problem with this?