### PR TITLE
cli: switch to passing argv to commands `run` methods

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -34,8 +34,8 @@ module GGem
     def run(args)
       begin
         cmd_name = args.shift
-        cmd = COMMANDS[cmd_name].new(args)
-        cmd.run
+        cmd = COMMANDS[cmd_name].new
+        cmd.run(args)
       rescue CLIRB::HelpExit
         @stdout.puts cmd.help
       rescue CLIRB::VersionExit


### PR DESCRIPTION
The goal here is to remove as much state from commands as possible.
Specifically you shouldn't have to know anything about a specific
argv to build a command's help message.  This moves argv handling
from the init method to the run method.

This will specifically be used in a coming effort that will provide
more rich command listings on invalid command help output.  I want
to show command descriptions info listed alongside each command
but will need to init each command to get this info (it is in the
help message right now).  I don't want to have to pass bogus argv
data just to get part of the help message.

@jcredding moar FYI.  Again, this is a "hotfix we may discard later".  You can yay/nay this in a later PR where I do something meaningful.