### PR TITLE
cli: switch to passing stderr/stdout to command `run` methods

### DIFF
--- a/lib/ggem/cli/commands.rb
+++ b/lib/ggem/cli/commands.rb
@@ -16,9 +16,7 @@ class GGem::CLI
       @clirb = CLIRB.new
     end
 
-    def new(*args)
-      self
-    end
+    def new; self; end
 
     def run(argv)
       @clirb.parse!([@name, argv].flatten.compact)
@@ -43,16 +41,16 @@ class GGem::CLI
 
     module InstanceMethods
 
-      def initialize(stdout = nil, stderr = nil)
-        @stdout = stdout || $stdout
-        @stderr = stderr || $stderr
+      def initialize
         @clirb  = CLIRB.new
       end
 
       def clirb; @clirb; end
 
-      def run(argv)
+      def run(argv, stdout = nil, stderr = nil)
         @clirb.parse!(argv)
+        @stdout = stdout || $stdout
+        @stderr = stderr || $stderr
       end
 
     end
@@ -121,7 +119,7 @@ class GGem::CLI
   class GenerateCommand
     include GitRepoCommand
 
-    def run(argv)
+    def run(argv, *args)
       super
 
       begin
@@ -162,8 +160,9 @@ class GGem::CLI
         begin
           @spec = GGem::Gemspec.new(Dir.pwd)
         rescue GGem::Gemspec::NotFoundError => exception
-          @stderr.puts "There are no gemspecs at #{Dir.pwd}"
-          raise CommandExitError
+          error = ArgumentError.new("There are no gemspecs at #{Dir.pwd}")
+          error.set_backtrace(exception.backtrace)
+          raise error
         end
       end
 
@@ -184,7 +183,7 @@ class GGem::CLI
   class BuildCommand
     include GemspecCommand
 
-    def run(argv)
+    def run(argv, *args)
       super
       notify("#{@spec.name} #{@spec.version} built to #{@spec.gem_file}") do
         @spec.run_build_cmd
@@ -209,7 +208,7 @@ class GGem::CLI
       @build_command = BuildCommand.new(*args)
     end
 
-    def run(argv)
+    def run(argv, *args)
       super
       @build_command.run(argv)
       notify("#{@spec.name} #{@spec.version} installed to system gems") do
@@ -234,7 +233,7 @@ class GGem::CLI
       @build_command = BuildCommand.new(*args)
     end
 
-    def run(argv)
+    def run(argv, *args)
       super
       @build_command.run(argv)
 
@@ -257,7 +256,7 @@ class GGem::CLI
     include GitRepoCommand
     include GemspecCommand
 
-    def run(argv)
+    def run(argv, *args)
       super
 
       begin
@@ -303,7 +302,7 @@ class GGem::CLI
       @push_command = PushCommand.new(*args)
     end
 
-    def run(argv)
+    def run(argv, *args)
       super
       @tag_command.run(argv)
       @push_command.run(argv)


### PR DESCRIPTION
The goal here is to remove as much state from commands as possible.
Specifically you shouldn't have to know anything about I/O to build
a command's help message. This moves I/O handling from the init
method to the run method.

This will specifically be used in a coming effort that will provide
more rich command listings on invalid command help output. I want
to show command description info listed alongside each command
but will need to init each command to get this info (it is in the
help message right now). I don't want to have to think about any I/O
concerns just to get part of the help message.

Incidentally, this cleaned up a lot of boilerplate code and made the
invalid command's `new` method a trivial implementation that is
obvious given its design.  Note: I chose to switch the gemspec command
mixin's "not found" handling to raise an argument error just like the
generate command does.  I had to make this switch b/c I can no longer
deal with stderr in init, but I think it is a good switch nonetheless.

@jcredding again with moar FYI.  This is similar to #30 and is a "hotfix we may discard" with the same justifications.  I promise I'll have a PR that needs your feedback and is meaningful soon (should be the next one on this feature branch!).