### PR TITLE
cli: new command config api; rich cmd lists for invalid help msgs

### DIFF
--- a/lib/ggem/cli.rb
+++ b/lib/ggem/cli.rb
@@ -6,19 +6,13 @@ module GGem
 
   class CLI
 
-    COMMANDS = Hash.new{ |h, k| InvalidCommand.new(k) }.tap do |h|
-      h['generate'] = GenerateCommand
-      h['g']        = GenerateCommand
-      h['build']    = BuildCommand
-      h['b']        = BuildCommand
-      h['install']  = InstallCommand
-      h['i']        = InstallCommand
-      h['push']     = PushCommand
-      h['p']        = PushCommand
-      h['tag']      = TagCommand
-      h['t']        = TagCommand
-      h['release']  = ReleaseCommand
-      h['r']        = ReleaseCommand
+    COMMANDS = CommandSet.new{ |unknown| InvalidCommand.new(unknown) }.tap do |c|
+      c.add(GenerateCommand, 'generate', 'g')
+      c.add(BuildCommand,    'build',    'b')
+      c.add(InstallCommand,  'install',  'i')
+      c.add(PushCommand,     'push',     'p')
+      c.add(TagCommand,      'tag',      't')
+      c.add(ReleaseCommand,  'release',  'r')
     end
 
     def self.run(args)
@@ -34,7 +28,7 @@ module GGem
     def run(args)
       begin
         cmd_name = args.shift
-        cmd = COMMANDS[cmd_name].new
+        cmd = COMMANDS[cmd_name]
         cmd.run(args)
       rescue CLIRB::HelpExit
         @stdout.puts cmd.help


### PR DESCRIPTION
This reworks the API used to configure commands on the CLI.  The
overall goal here is to provide rich cmd lists for the general CLI
`--help` flag.

Here is a before/after of the `--help` output:

```
(before)
$ ggem -h
Usage: ggem [COMMAND] [options]

Commands: build, g, generate, install, push
Options:
        --version
        --help
```

```
(after)
$ ggem -h
Usage: ggem [COMMAND] [options]

Options:
        --version
        --help

Commands:
  generate (g) # Create a gem given a GEM-NAME
  build    (b) # Build ggem-1.7.0.gem into the pkg directory
  install  (i) # Build and install ggem-1.7.0.gem into system gems
  push     (p) # Push built ggem-1.7.0.gem to https://rubygems.org
  tag      (t) # Tag v1.7.0 and push git commits/tags
  release  (r) # Tag v1.7.0 and push built ggem-1.7.0.gem to https://rubygems.org
```

The new version not only lists the cmd names but also any aliases
plus a one-line summary description.  Also the commands are listed
in a custom order (not alphabetical).  The motivation for this
change comes from using bundler's rake gem tasks.  Due to the nature
of rake, you can run `rake -T` and get a similar task listing.  I
found myself relying on this to quickly remind myself of the commands
and to quickly verify the gem source I am about to release to.

To implement this, I created a custom command set class to store the
configured commands.  The `add` method allows specifying any aliases
right alongside the name.  The class keeps track on add order and
lists the commands in this order in its `to_s` representation.

Also included is each commands summary.  The commands have been updated
to break out the summary from the help message and I added a summary
for the generate command.

All of this provides the rich output I have become accustomed to using
Bundler's rake tasks.

@jcredding ready for review.

Ok this is that PR I talked about in the previous efforts (#29, #30, #31).  What do you think of all this.  It turned out to be a lot of rework to get the final product but I really like the finished product.  One thing to note: since some commands are only relevant on gems, you get a different listing of commands on non-gem pwds:

```
$ cd /some/non/gem
$ ggem -h
Usage: ggem [COMMAND] [options]

Options: 
        --version
        --help

Commands:
  generate (g) # Create a gem given a GEM-NAME
``` 

Anyway, let me know your thoughts.  I've departed pretty big from the command handling done in our other libs like ardb.  Maybe we can go back to those and update?