### PR TITLE
add `.gitkeep` files for test/system and test/unit dirs

### DIFF
--- a/lib/ggem/template.rb
+++ b/lib/ggem/template.rb
@@ -31,6 +31,8 @@ module GGem
       save_file("test_support_factory.rb.erb", "test/support/factory.rb")
 
       save_empty_file("log/.gitkeep")
+      save_empty_file("test/system/.gitkeep")
+      save_empty_file("test/unit/.gitkeep")
       save_empty_file("tmp/.gitkeep")
     end
 

--- a/test/support/name_set.rb
+++ b/test/support/name_set.rb
@@ -31,6 +31,8 @@ module GGem
           "test/support/factory.rb",
 
           "log/.gitkeep",
+          "test/system/.gitkeep",
+          "test/unit/.gitkeep",
           "tmp/.gitkeep",
         ]
       end


### PR DESCRIPTION
I noticed these were missing when I created a new gem recently.
This adds in the gitkeeps to let these dirs get pushed early on.

@jcredding ready for review.