### PR TITLE
update to generate CircleCI config for multi Ruby version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The `generate` command creates a folder and files for developing, testing, and r
 * adds `TODO` entries in files where user input is needed
 * source control using [Git](https://git-scm.com/)
 * test using [Assert](https://github.com/redding/assert)
+* CI with CircleCI
+  * see `.circleci/config.yml`
+  * need to replace `/todo_org_name` with the gem's org name (ie `/redding`)
 
 You can also call this command using the `g` alias: `ggem g -h`.
 

--- a/lib/ggem/template.rb
+++ b/lib/ggem/template.rb
@@ -11,12 +11,15 @@ module GGem
 
     def save
       save_folder # (gem root path)
+      save_folder ".circleci"
       save_folder "lib/#{@gem.ruby_name}"
       save_folder "test/support"
       save_folder "test/system"
       save_folder "test/unit"
       save_folder "log"
       save_folder "tmp"
+
+      save_file("circleci_config.yml.erb", ".circleci/config.yml")
 
       save_file("gitignore.erb", ".gitignore")
       save_file("Gemfile.erb",   "Gemfile")

--- a/lib/ggem/template_file/circleci_config.yml.erb
+++ b/lib/ggem/template_file/circleci_config.yml.erb
@@ -1,0 +1,82 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+
+jobs:
+  test_ruby_2.3.7:
+    working_directory: ~/todo_org_name/<%= @gem.name %>/ruby-2.3.7
+    docker:
+       - image: circleci/ruby:2.3.7
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.3.7-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.3.7-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+
+  test_ruby_2.4.5:
+    working_directory: ~/todo_org_name/<%= @gem.name %>/ruby-2.4.5
+    docker:
+       - image: circleci/ruby:2.4.5
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.4.5-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.4.5-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+
+  test_ruby_2.5.3:
+    working_directory: ~/todo_org_name/<%= @gem.name %>/ruby-2.5.3
+    docker:
+       - image: circleci/ruby:2.5.3
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.5.3-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.5.3-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+workflows:
+  version: 2
+  test_ruby_versions:
+    jobs:
+      - test_ruby_2.3.7
+      - test_ruby_2.4.5
+      - test_ruby_2.5.3

--- a/test/support/name_set.rb
+++ b/test/support/name_set.rb
@@ -6,6 +6,7 @@ module GGem
 
       def expected_folders
         [ "",
+          ".circleci",
           "lib",
           "lib/#{@ruby_name}",
           "test",
@@ -18,7 +19,9 @@ module GGem
       end
 
       def expected_files
-        [ ".gitignore",
+        [ ".circleci/config.yml",
+
+          ".gitignore",
           "Gemfile",
           "#{@name}.gemspec",
           "README.md",


### PR DESCRIPTION
This is something we are trying to move to in our gem setups. Note:
this generates the config with a `/todo_org_name` path - this is
a setup step that needs to be addressed.

@jcredding ready for review.